### PR TITLE
Remove test packages from distribusion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,9 @@ if __name__ == "__main__":
         long_description_content_type="text/markdown",
         name="asynccpu",
         packages=find_packages(
-            include=["asynccpu", "asynccpu.*", "tests", "tests.*"]
+            include=["asynccpu", "asynccpu.*"]
         ),  # noqa: E501 pylint: disable=line-too-long
-        package_data={"asynccpu": ["py.typed"], "tests": ["*"]},
+        package_data={"asynccpu": ["py.typed"]},
         python_requires=">=3.8",
         test_suite="tests",
         tests_require=["pytest>=3"],

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,7 @@ if __name__ == "__main__":
         long_description=readme,
         long_description_content_type="text/markdown",
         name="asynccpu",
-        packages=find_packages(
-            include=["asynccpu", "asynccpu.*"]
-        ),  # noqa: E501 pylint: disable=line-too-long
+        packages=find_packages(include=["asynccpu", "asynccpu.*"]),
         package_data={"asynccpu": ["py.typed"]},
         python_requires=">=3.8",
         test_suite="tests",


### PR DESCRIPTION
When distribute tests package,
the tests of the code that uses the package
may refer to the test code of the distribution package
and cause strange behavor.