### PR TITLE
Fix bug that CodeQL workflow doesn't work

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,4 +29,4 @@ jobs:
       # only required for workflows in private repositories
       actions: read
       contents: read
-    uses: ./.github/workflows/reusable-codeql-analysis.yml@main
+    uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-codeql-analysis.yml@main


### PR DESCRIPTION
This pull request updates the `codeql.yml` workflow to use a shared reusable workflow from an external repository instead of a local one. This allows the workflow to leverage centralized maintenance and updates.

Workflow configuration update:

* Updated the `jobs` section in `.github/workflows/codeql.yml` to use the `reusable-codeql-analysis.yml` workflow from the `yukihiko-shinoda/invoke-lint` repository instead of the local version.