### PR TITLE
Fix bug that Qlty coverage is reported as 0%

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,9 @@ filename = "asynccpu/__init__.py"
 search = '__version__ = "{current_version}"'
 replace = '__version__ = "{new_version}"'
 
+[tool.coverage.paths]
+source = ["asynccpu/"]
+
 [tool.coverage.report]
 exclude_also = [
     # Assume `if TYPE_CHECKING: ... else: ...` block is covered · Issue #831 · nedbat/coveragepy


### PR DESCRIPTION
This pull request adds a configuration update to improve code coverage reporting for the `asynccpu` package.

Configuration improvements:

* Added a `[tool.coverage.paths]` section to `pyproject.toml` to specify `asynccpu/` as the source directory for coverage analysis.