### PR TITLE
Fix bug that Qlty coverage is reported as 0%

### DIFF
--- a/.github/workflows/qlty.yml
+++ b/.github/workflows/qlty.yml
@@ -8,3 +8,5 @@ jobs:
       contents: read
       id-token: write
     uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-qlty.yml@main
+    with:
+      add-prefix: 'asynccpu/'


### PR DESCRIPTION
This pull request introduces a small configuration update to the GitHub Actions workflow. The change adds a prefix to the quality linting step to help organize or distinguish the results.

* Workflow configuration:
  * [`.github/workflows/qlty.yml`](diffhunk://#diff-5b16d201a687c908f0427a1d319b9d2002e28137c74d84454bf006c1ef2ddecbR11-R12): Added the `add-prefix: 'asynccpu/'` input to the reusable lint workflow invocation.