### PR TITLE
Follow the specification change of reusable workflow for testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,9 @@ on:
     branches:
       - main
 jobs:
-  call-workflow:
+  call-workflow-test:
     uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-test.yml@main
     with:
       support-python-versions: "[ '3.13', '3.12', '3.11', '3.10', '3.9', '3.8' ]"
+  call-workflow-lint:
+    uses: yukihiko-shinoda/invoke-lint/.github/workflows/reusable-lint.yml@main


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration. It renames a job and adds a new job to the workflow.

- Workflow job updates:
  * Renamed the `call-workflow` job to `call-workflow-test` in `.github/workflows/test.yml`.
  * Added a new job called `call-workflow-lint` that also uses the reusable workflow in `.github/workflows/test.yml`.