### PR TITLE
Hotfix keyboardinterrupt handling

### DIFF
--- a/.devcontainer/compose.yml
+++ b/.devcontainer/compose.yml
@@ -24,6 +24,7 @@ services:
       # Update this to wherever you want VS Code to mount the folder of your project
       - .:/workspace:cached
       - /workspace/.venv
+      - ~/.claude:/root/.claude:cached
 
       # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
       # - /var/run/docker.sock:/var/run/docker.sock 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM futureys/claude-code-python-development:20250915024000
+FROM futureys/claude-code-python-development:20260221145500
 COPY pyproject.toml /workspace/
 # - Using uv in Docker | uv
 #   https://docs.astral.sh/uv/guides/integration/docker/#caching
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync
+    uv sync --python 3.13
 COPY . /workspace
 ENTRYPOINT [ "uv", "run" ]
 CMD ["invoke", "test.coverage"]

--- a/asynccpu/subprocess.py
+++ b/asynccpu/subprocess.py
@@ -133,6 +133,22 @@ def run(
             return loop.run_until_complete(coro)
         # Reason: Testing in Subprocess noqa: ERA001
         except KeyboardInterrupt:  # pragma: no cover
+            # Reason: When KeyboardInterrupt (e.g. Windows CTRL_C_EVENT) is raised, the
+            # coroutine is suspended at an `await` and its task is still pending.
+            # We must cancel and await all pending tasks so their except/finally cleanup
+            # blocks execute before we terminate descendant processes.
+            # This mirrors the behaviour of asyncio.run() / Runner.__exit__ in CPython 3.11+,
+            # which calls _cancel_all_tasks() before re-raising KeyboardInterrupt.
+            # see:
+            #   - CPython asyncio/runners.py _cancel_all_tasks
+            #     https://github.com/python/cpython/blob/main/Lib/asyncio/runners.py
+            #   - asyncio.run() documentation
+            #     https://docs.python.org/3/library/asyncio-runner.html#asyncio.run
+            pending = asyncio.all_tasks(loop)
+            for task in pending:
+                task.cancel()
+            if pending:
+                loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
             cancel_coroutine(logger)
             raise
         finally:

--- a/compose.yml
+++ b/compose.yml
@@ -3,3 +3,11 @@ services:
     build:
       context: .
     image: futureys/asynccpu:development
+    volumes:
+      - .:/workspace:cached
+      - /workspace/.venv
+      # - Using uv in Docker | uv
+      #   https://docs.astral.sh/uv/guides/integration/docker/#caching
+      - uv-cache:/root/.cache/uv
+volumes:
+  uv-cache:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,6 +174,12 @@ exclude = [
 [tool.mypy]
 strict = true
 
+[tool.pylint]
+disable = [
+    # We check line length by flake8-bugbear B950.
+    "line-too-long",
+]
+
 [tool.pylint.basic]
 docstring-min-length = "7"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,6 +214,16 @@ show_mi = true
 line-length = 119
 
 [tool.ruff.lint]
+# Avoiding flagging (and removing) any codes starting with `H` from any
+# `# noqa` directives, despite Ruff's lack of support for `hacking`.
+# - Long import statement violates flake8: H301: one import per line · Issue #1220 · psf/black
+#   https://github.com/psf/black/issues/1220#issuecomment-570970250
+# - Bug #2123810 “H301 with long line” : Bugs : hacking
+#   https://bugs.launchpad.net/hacking/+bug/2123810
+external = [
+    "DUO",  # dlint
+    "H",  # Openstack/hacking
+]
 select = ["ALL"]
 ignore = [
     # lint.pydocstyle


### PR DESCRIPTION
This pull request introduces improvements to Docker and development environment configuration, as well as enhancements to subprocess signal handling and Python linting. The most significant changes focus on better caching for dependencies, more robust subprocess task cleanup, and improved configuration for linting tools.

**Docker and development environment improvements:**

* Updated the base image in `Dockerfile` to a newer version and configured `uv sync` to use Python 3.13 for improved compatibility and future-proofing.
* Added persistent cache volume mounts for `uv` dependency management in both `.devcontainer/compose.yml` and `compose.yml`, which will speed up dependency installation and improve developer experience. [[1]](diffhunk://#diff-85dc84cf35cfe2518db19af9c6e123046c01aa36bbe707e6ce5d469ea9dd1d43R27) [[2]](diffhunk://#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588R6-R13)

**Subprocess handling enhancements:**

* Improved `sigterm_handler` in `asynccpu/subprocess.py` to ensure all pending asyncio tasks are cancelled and awaited on `KeyboardInterrupt`, mirroring modern CPython behavior for safer cleanup of subprocesses.

**Linting configuration:**

* Added and updated `pylint` configuration in `pyproject.toml` to disable line length checks (since they're handled by `flake8-bugbear`) and set minimum docstring length, leading to clearer and more consistent code quality checks.